### PR TITLE
Fixing amount displaying total without discounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Change amount total to reduce discounts.
+
 ## [0.1.2] - 2020-02-10
 ### Fixed
 - Pass order total value to amount.

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -27,7 +27,7 @@ export function handleEvents(e: PixelMessage) {
       createIFrame({
         confirm: window.__2performant.confirm,
         campaignUnique: window.__2performant.campaignUnique,
-        amount: e.data.transactionTotal,
+        amount: e.data.transactionTotal - e.data.transactionDiscounts - e.data.transactionTax - e.data.transactionShipping,
         description: productNames(e.data.transactionProducts),
         transactionId: e.data.transactionId,
       })


### PR DESCRIPTION
Changes made duo to clients request, seems the right way to do this.
Nowadays we get the amount total including a lot of things, like shipping, and other tax.
So, in the following scenario, we are getting the amount like: 
Sale Amount = Final Cart Value - Valueadd Tax (VAT) - Shipping Tax - Other Discounts